### PR TITLE
fix: using correct repo name for lens-k8s-proxy

### DIFF
--- a/packages/ensure-binaries/src/index.ts
+++ b/packages/ensure-binaries/src/index.ts
@@ -167,7 +167,7 @@ class LensK8sProxyDownloader extends BinaryDownloader {
     const binaryName = getBinaryName("lens-k8s-proxy", { forPlatform: args.platform });
 
     super({ ...args, binaryName }, bar);
-    this.url = `https://github.com/Open-Lens/app-k8s-proxy/releases/download/v${args.version}/lens-k8s-proxy-${args.platform}-${args.downloadArch}`;
+    this.url = `https://github.com/Open-Lens/lens-k8s-proxy/releases/download/v${args.version}/lens-k8s-proxy-${args.platform}-${args.downloadArch}`;
   }
 }
 


### PR DESCRIPTION
Use the "lens-k8s-prox" binary from our repo